### PR TITLE
Actually remove linkedin

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,11 +54,6 @@
                     </a>
                 </li>
                 <li class='pull-right'>
-                    <a href='https://www.linkedin.com/company/overcast-network' target='_blank'>
-                        LinkedIn
-                    </a>
-                </li>
-                <li class='pull-right'>
                     <a href='https://discord.gg/PGM' target='_blank'>
                         Discord
                     </a>


### PR DESCRIPTION
The latest commit by @tonybruess said that he removed LinkedIn url, but it wasn't actually removed.